### PR TITLE
Bugfix: #2 Bemmer.create() break block with hyphen

### DIFF
--- a/src/__tests__/bemmer.spec.es6
+++ b/src/__tests__/bemmer.spec.es6
@@ -7,6 +7,8 @@ describe('Bemmer.create()', () => {
     ['__zzz__yyy', { xxx: true, www: false }],
     [null, { zzz: true }],
     ['__zzz', null],
+    ['__zzz_yyy', { xxx: true }],
+    ['__zz!z$&y@yy', { xxx: true }],
   ];
 
   it('#1', () => {
@@ -16,6 +18,8 @@ describe('Bemmer.create()', () => {
       'aaa__zzz__yyy aaa__zzz__yyy--xxx',
       'aaa aaa--zzz',
       'aaa__zzz',
+      'aaa__zzz_yyy aaa__zzz_yyy--xxx',
+      'aaa__zz!z$&y@yy aaa__zz!z$&y@yy--xxx',
     ];
 
     testArgsOfBuilder.forEach((args, i) => {
@@ -30,6 +34,8 @@ describe('Bemmer.create()', () => {
       'aaa__bbb__zzz__yyy aaa__bbb__zzz__yyy--ccc aaa__bbb__zzz__yyy--xxx',
       'aaa__bbb aaa__bbb--ccc aaa__bbb--zzz',
       'aaa__bbb__zzz aaa__bbb__zzz--ccc',
+      'aaa__bbb__zzz_yyy aaa__bbb__zzz_yyy--ccc aaa__bbb__zzz_yyy--xxx',
+      'aaa__bbb__zz!z$&y@yy aaa__bbb__zz!z$&y@yy--ccc aaa__bbb__zz!z$&y@yy--xxx',
     ];
 
     testArgsOfBuilder.forEach((args, i) => {
@@ -44,6 +50,8 @@ describe('Bemmer.create()', () => {
       'aaa__bbb__zzz__yyy aaa__bbb__zzz__yyy--xxx ccc__zzz__yyy ccc__zzz__yyy--xxx',
       'aaa__bbb aaa__bbb--zzz ccc ccc--zzz',
       'aaa__bbb__zzz ccc__zzz',
+      'aaa__bbb__zzz_yyy aaa__bbb__zzz_yyy--xxx ccc__zzz_yyy ccc__zzz_yyy--xxx',
+      'aaa__bbb__zz!z$&y@yy aaa__bbb__zz!z$&y@yy--xxx ccc__zz!z$&y@yy ccc__zz!z$&y@yy--xxx',
     ];
 
     testArgsOfBuilder.forEach((args, i) => {
@@ -58,6 +66,8 @@ describe('Bemmer.create()', () => {
       'aaa__bbb__zzz__yyy aaa__bbb__zzz__yyy--xxx aaa__bbb__zzz__yyy--ccc ddd__zzz__yyy ddd__zzz__yyy--xxx ddd__zzz__yyy--ccc',
       'aaa__bbb aaa__bbb--zzz aaa__bbb--ccc ddd ddd--zzz ddd--ccc',
       'aaa__bbb__zzz aaa__bbb__zzz--ccc ddd__zzz ddd__zzz--ccc',
+      'aaa__bbb__zzz_yyy aaa__bbb__zzz_yyy--xxx aaa__bbb__zzz_yyy--ccc ddd__zzz_yyy ddd__zzz_yyy--xxx ddd__zzz_yyy--ccc',
+      'aaa__bbb__zz!z$&y@yy aaa__bbb__zz!z$&y@yy--xxx aaa__bbb__zz!z$&y@yy--ccc ddd__zz!z$&y@yy ddd__zz!z$&y@yy--xxx ddd__zz!z$&y@yy--ccc',
     ];
 
     testArgsOfBuilder.forEach((args, i) => {

--- a/src/bemmer.es6
+++ b/src/bemmer.es6
@@ -2,7 +2,6 @@
 // Bemmer v0.3.1 by @axross
 // https://github.com/axross/bemmer
 //
-const BLOCK_REGEXP    = /^([^_\-\s]+)/g;
 const ELEMENT_REGEXP  = /__([^_\-\s]+)/g;
 const MODIFIER_REGEXP = /\-\-([^_\-\s]+)/g;
 
@@ -38,9 +37,9 @@ class Bem {
   }
 
   static fromClassName(className) {
-    const block = extract(BLOCK_REGEXP, className)[0];
-    const elements = extract(ELEMENT_REGEXP, className);
-    const modifiers = extract(MODIFIER_REGEXP, className);
+    const block = __extractBlock(className);
+    const elements = __extract(ELEMENT_REGEXP, className);
+    const modifiers = __extract(MODIFIER_REGEXP, className);
 
     return new Bem({ block, elements, modifiers });
   }
@@ -69,8 +68,8 @@ const generateBuilder = (...classNames) => {
     return bems
       .map(bem => {
         return bem.append({
-          elements: parseElements(elements),
-          modifiers: parseModifiers(modifiers)
+          elements: __parseElements(elements),
+          modifiers: __parseModifiers(modifiers)
         });
       })
       .map(bem => bem.toString())
@@ -88,7 +87,17 @@ const generateBuilder = (...classNames) => {
   return builder;
 };
 
-const extract = (regexp, string) => {
+const __extractBlock = value => {
+  const block = value.split('__')[0].split('--')[0];
+
+  if (value === '') {
+    throw new Error('Invalid className given');
+  }
+
+  return block;
+};
+
+const __extract = (regexp, string) => {
   const clonedRegexp = new RegExp(regexp);
   let extracted = [];
 
@@ -103,12 +112,12 @@ const extract = (regexp, string) => {
   return extracted;
 }
 
-const parseElements = (elements) => {
+const __parseElements = (elements) => {
   return elements.split('__')
     .filter(element => element.length > 0);
 };
 
-const parseModifiers = (modifiers) => {
+const __parseModifiers = (modifiers) => {
   return Object.keys(modifiers)
     .filter(modifier => !!modifiers[modifier])
     .filter(modifier => modifier.length > 0);


### PR DESCRIPTION
Like this:

> Bemmer.create('foo-bar')
> // => { [Function: builder] bems: [ { block: 'foo', elements: [], modifiers: [] } ] }
> It should block is foo-bar.

fix #2
